### PR TITLE
Xygeni-Bumper - update 2 dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <webwolf.port>9090</webwolf.port>
     <wiremock.version>3.12.1</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.18</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.9.0</zxcvbn.version>
   </properties>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -105,7 +105,7 @@
     <webwolf.port>9090</webwolf.port>
     <wiremock.version>3.12.1</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.18</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.9.0</zxcvbn.version>
   </properties>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.7 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.7 
### 📝 Description 

CVE-2013-7285 Xstream API versions up to 1.4.6 and version 1.4.10, if the security framework has not been initialized, may allow a remote attacker to run arbitrary shell commands by manipulating the processed input stream when unmarshaling XML or any supported format. e.g. JSON. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2013-7285 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39146 XStream is a simple library to serialize objects to XML and back again. In affected versions this vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39146 



