### PR TITLE
Xygeni-Bumper - update 8 dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <webwolf.port>9090</webwolf.port>
     <wiremock.version>3.12.1</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.20</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.9.0</zxcvbn.version>
   </properties>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.7 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.7 
### 📝 Description 

CVE-2013-7285 Xstream API versions up to 1.4.6 and version 1.4.10, if the security framework has not been initialized, may allow a remote attacker to run arbitrary shell commands by manipulating the processed input stream when unmarshaling XML or any supported format. e.g. JSON. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2013-7285 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39153 XStream is a simple library to serialize objects to XML and back again. In affected versions this vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream, if using the version out of the box with Java runtime version 14 to 8 or with JavaFX installed. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39153 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39148 XStream is a simple library to serialize objects to XML and back again. In affected versions this vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39148 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.9 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.9 
### 📝 Description 

CVE-2016-3674 Multiple XML external entity (XXE) vulnerabilities in the (1) Dom4JDriver, (2) DomDriver, (3) JDomDriver, (4) JDom2Driver, (5) SjsxpDriver, (6) StandardStaxDriver, and (7) WstxDriver drivers in XStream before 1.4.9 allow remote attackers to read arbitrary files via a crafted XML document. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2016-3674 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.20 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.20 
### 📝 Description 

CVE-2022-41966 XStream serializes Java objects to XML and back again. Versions prior to 1.4.20 may allow a remote attacker to terminate the application with a stack overflow error, resulting in a denial of service only via manipulation the processed input stream. The attack uses the hash code implementation for collections and maps to force recursive hash calculation causing a stack overflow. This issue is patched in version 1.4.20 which handles the stack overflow and raises an InputManipulationException instead. A potential workaround for users who only use HashMap or HashSet and whose XML refers these only as default map or set, is to change the default implementation of java.util.Map and java.util per the code example in the referenced advisory. However, this implies that your application does not care about the implementation of the map and all elements are comparable. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2022-41966 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21344 XStream is a Java library to serialize objects to XML and back again. In XStream before version 1.4.16, there is a vulnerability which may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types. If you rely on XStream's default blacklist of the Security Framework, you will have to use at least version 1.4.16. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21344 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39140 XStream is a simple library to serialize objects to XML and back again. In affected versions this vulnerability may allow a remote attacker to allocate 100% CPU time on the target system depending on CPU type or parallel execution of such a payload resulting in a denial of service only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39140 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.20 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.20 
### 📝 Description 

CVE-2022-40151 Those using Xstream to seralize XML data may be vulnerable to Denial of Service attacks (DOS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by stackoverflow. This effect may support a denial of service attack. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2022-40151 



